### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/releases/django-rest-pandas-0.3.2.md
+++ b/docs/releases/django-rest-pandas-0.3.2.md
@@ -5,7 +5,7 @@ date: 2015-04-20
 
 # DRP 0.3.2
 
-This release is just to verify compatiblity with Django 1.8 and pandas 0.16.0.  Older versions should still work, though note that Django 1.6 is no longer being tested against.
+This release is just to verify compatibility with Django 1.8 and pandas 0.16.0.  Older versions should still work, though note that Django 1.6 is no longer being tested against.
 
 The only actual code change is https://github.com/wq/django-rest-pandas/commit/5faa4ec4d32466dac89ef117392faa87428a801f, which switches the JSON renderer from a default of `orient="index"` to `orient="records"` <strike>to get around a breaking test</strike> because it's a more reasonable default.  You can restore the old behavior by subclassing `PandasJSONRenderer` and overriding `get_pandas_kwargs()`, but:
 1. As is noted in the README, the [CSV renderer](../renderers/csv.md) is the one you probably want to be using anyway.  You can use [wq/pandas.js](../@wq/pandas.md) to convert CSV to JSON after you've loaded it on the client.

--- a/docs/releases/django-rest-pandas-0.5.0.md
+++ b/docs/releases/django-rest-pandas-0.5.0.md
@@ -5,6 +5,6 @@ date: 2016-11-08
 
 # DRP 0.5.0
 
-Django REST Pandas 0.5.0 introduces a simple `PandasHTMLRenderer` for use in a browseable visualization API (#2).  To enable it by default, you just need to add `rest_pandas` to your `INSTALLED_APPS`.  You will need a template called `rest_pandas.html`, or you can install [django-mustache](https://github.com/wq/django-mustache) to use the provided mustache template (which is optimized for integration with a [wq-powered](https://wq.io/) application).
+Django REST Pandas 0.5.0 introduces a simple `PandasHTMLRenderer` for use in a browsable visualization API (#2).  To enable it by default, you just need to add `rest_pandas` to your `INSTALLED_APPS`.  You will need a template called `rest_pandas.html`, or you can install [django-mustache](https://github.com/wq/django-mustache) to use the provided mustache template (which is optimized for integration with a [wq-powered](https://wq.io/) application).
 
 This release also includes updates for pandas 0.19 and drops support for Django REST Framework 2.4 (#23).

--- a/docs/renderers/csv.md
+++ b/docs/renderers/csv.md
@@ -7,7 +7,7 @@ tag: text/csv
 
 Django REST Pandas' CSV [renderer class][renderers] provides `text/csv` support by calling `to_csv()` on the DataFrame instance.
 
-> To facilitate data API building, the CSV renderer is the default in Django REST Pandas.  While the pandas [JSON renderer][json] is also supported, the primary reason for making CSV the default is the compactness it provides over JSON when serializing time series and other tablular data.
+> To facilitate data API building, the CSV renderer is the default in Django REST Pandas.  While the pandas [JSON renderer][json] is also supported, the primary reason for making CSV the default is the compactness it provides over JSON when serializing time series and other tabular data.
 
 The default CSV output from DRP will have single row of column headers, making it suitable as-is for use with e.g. `d3.csv()`.   However, DRP is often used with the custom serializers below to produce a dataframe with nested multi-row column headers.  This is harder to parse with `d3.csv()` but can be easily processed by [@wq/pandas], an extension to d3.js.
 


### PR DESCRIPTION
There are small typos in:
- docs/releases/django-rest-pandas-0.3.2.md
- docs/releases/django-rest-pandas-0.5.0.md
- docs/renderers/csv.md

Fixes:
- Should read `tabular` rather than `tablular`.
- Should read `compatibility` rather than `compatiblity`.
- Should read `browsable` rather than `browseable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md